### PR TITLE
VE-1051: Persist selected right pane when clicking on a different element

### DIFF
--- a/app/js/mms/controllers/tool.controller.js
+++ b/app/js/mms/controllers/tool.controller.js
@@ -128,6 +128,9 @@ function($scope, $rootScope, $state, $uibModal, $q, $timeout, hotkeys,
         $scope.specInfo.refId = elementOb._refId;
         $scope.specInfo.commitId = commitId ? commitId : elementOb._commitId;
         $scope.specInfo.mmsDisplayOldContent = displayOldContent;
+        if($scope.show.element) {
+            $rootScope.ve_tbApi.select('element-viewer');
+        }
         if ($scope.specApi.setEditing) {
             $scope.specApi.setEditing(false);
         }

--- a/app/js/mms/controllers/tool.controller.js
+++ b/app/js/mms/controllers/tool.controller.js
@@ -128,9 +128,6 @@ function($scope, $rootScope, $state, $uibModal, $q, $timeout, hotkeys,
         $scope.specInfo.refId = elementOb._refId;
         $scope.specInfo.commitId = commitId ? commitId : elementOb._commitId;
         $scope.specInfo.mmsDisplayOldContent = displayOldContent;
-        $rootScope.ve_tbApi.select('element-viewer');
-
-        showPane('element');
         if ($scope.specApi.setEditing) {
             $scope.specApi.setEditing(false);
         }

--- a/src/services/UxService.js
+++ b/src/services/UxService.js
@@ -30,7 +30,7 @@ function UxService($rootScope) {
                 spinner: false, onClick: function() {$rootScope.$broadcast(button);},
                 dynamic_buttons: [getToolbarButton("element-editor-saveall")]};
       case "element-history":
-        return {id: button, icon: 'fa-history', selected: true, active: true, permission:true, tooltip: 'Element History', 
+        return {id: button, icon: 'fa-history', selected: false, active: true, permission:true, tooltip: 'Element History',
                 spinner: false, onClick: function() {$rootScope.$broadcast(button);},
                 dynamic_buttons: [getToolbarButton("element-editor-saveall")]};
       case "element-editor":
@@ -51,7 +51,7 @@ function UxService($rootScope) {
         return {id: button, icon: 'fa-code-fork', selected: false, active: true, permission: true, tooltip: 'Branches and Tags',
                 spinner: false, onClick: function() {$rootScope.$broadcast(button);}};
       case "jobs":
-        return {id: button, icon: 'fa-sort-amount-desc', selected: true, active: true, permission:true, tooltip: 'Jobs',
+        return {id: button, icon: 'fa-sort-amount-desc', selected: false, active: true, permission:true, tooltip: 'Jobs',
                 spinner: false, onClick: function() {$rootScope.$broadcast(button);}};
       case "element-editor-save":
         return {id: button, icon: 'fa-save', dynamic: true, selected: false, active: false, permission:true, tooltip: 'Save',


### PR DESCRIPTION
element-viewer should be. 
Also remove logic that default to element-viewer pane whenever a new element is selected so that users dont have to keep reselecting the previously selected right pane.